### PR TITLE
feat(cli): add --allow flag to extend allowed directories at startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
+    "smoke": "node scripts/smoke-stdio.mjs",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "npm run build",
     "clean": "rm -rf dist",
@@ -80,4 +81,4 @@
     "LICENSE",
     "CHANGELOG.md"
   ]
-}
+  }

--- a/scripts/smoke-stdio.mjs
+++ b/scripts/smoke-stdio.mjs
@@ -1,0 +1,52 @@
+// Minimal MCP stdio smoke test for --allow
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { spawn } from 'node:child_process';
+
+// Usage: node scripts/smoke-stdio.mjs --allow <dir> [--allow <dir2> ...]
+// or: pnpm smoke -- --allow <dir>
+
+const serverCmd = process.platform === 'win32' ? 'node' : 'node';
+const serverArgs = ['node_modules/tsx/dist/cli.mjs', 'src/index.ts', ...process.argv.slice(2)];
+
+const child = spawn(serverCmd, serverArgs, { stdio: 'pipe' });
+
+const transport = new StdioClientTransport({
+  command: serverCmd,
+  args: serverArgs,
+  // We reuse the spawned child by passing streams explicitly
+  // but StdioClientTransport can also spawn for us; here we attach.
+  stdio: {
+    stdin: child.stdin,
+    stdout: child.stdout,
+    stderr: child.stderr,
+  }
+});
+
+const client = new Client(
+  { name: 'smoke-client', version: '0.1.0' },
+  { capabilities: { tools: {}, prompts: {}, resources: {}, logging: {} } }
+);
+
+async function main() {
+  await client.connect(transport);
+  const tools = await client.listTools();
+  const hasList = tools.tools.some(t => t.name === 'fast_list_allowed_directories');
+  if (!hasList) throw new Error('Tool fast_list_allowed_directories not found');
+
+  const res = await client.callTool({ name: 'fast_list_allowed_directories', arguments: {} });
+  console.log('\nAllowed directories reported by server:\n');
+  for (const c of res.content) {
+    if (c.type === 'text') {
+      console.log(c.text);
+    }
+  }
+
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Smoke test failed:', err);
+  process.exit(1);
+});
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import { realpathSync, statSync } from 'fs';
 import path from 'path';
 
 // 상수들
@@ -17,11 +18,47 @@ export const CLAUDE_MAX_LINES = 2000;
 export const CLAUDE_MAX_DIR_ITEMS = 1000;
 
 // 유틸리티 함수들
+// Runtime-managed allowed directories (start with defaults)
+const allowedDirSet: Set<string> = new Set(
+  DEFAULT_ALLOWED_DIRECTORIES.map(p => path.resolve(p))
+);
+
+export function getAllowedDirectories(): string[] {
+  return Array.from(allowedDirSet);
+}
+
+export function addAllowedDirectories(paths: string[]): { added: string[]; skipped: { path: string; reason: string }[]; current: string[] } {
+  const added: string[] = [];
+  const skipped: { path: string; reason: string }[] = [];
+
+  for (const p of paths) {
+    try {
+      const candidate = path.isAbsolute(p) ? p : path.resolve(p);
+      const real = realpathSync(candidate);
+      const st = statSync(real);
+      if (!st.isDirectory()) {
+        skipped.push({ path: p, reason: 'not_a_directory' });
+        continue;
+      }
+      const resolved = path.resolve(real);
+      if (!allowedDirSet.has(resolved)) {
+        allowedDirSet.add(resolved);
+        added.push(resolved);
+      }
+    } catch {
+      skipped.push({ path: p, reason: 'invalid_or_inaccessible' });
+    }
+  }
+
+  return { added, skipped, current: Array.from(allowedDirSet) };
+}
+
 export function isPathAllowed(targetPath: string): boolean {
   const absolutePath = path.resolve(targetPath);
-  return DEFAULT_ALLOWED_DIRECTORIES.some(allowedDir => 
-    absolutePath.startsWith(path.resolve(allowedDir))
-  );
+  for (const allowedDir of allowedDirSet) {
+    if (absolutePath.startsWith(path.resolve(allowedDir))) return true;
+  }
+  return false;
 }
 
 export function safePath(inputPath: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,21 @@ import { realpathSync, statSync } from 'fs';
 import path from 'path';
 
 // 상수들
-export const DEFAULT_ALLOWED_DIRECTORIES = ['/tmp', process.cwd()];
+// Align defaults with original author intent: HOME, /tmp, user roots.
+export const DEFAULT_ALLOWED_DIRECTORIES = (() => {
+  const list: string[] = [];
+  const home = process.env.HOME || process.env.USERPROFILE || '/home';
+  list.push(home);
+  list.push('/tmp');
+  if (process.platform === 'win32') {
+    // Broad user root for Windows
+    list.push('C:/Users');
+  } else {
+    list.push('/Users', '/home');
+  }
+  // Dedupe and normalize
+  return Array.from(new Set(list.map(p => path.resolve(p))));
+})();
 export const DEFAULT_EXCLUDE_PATTERNS = [
   '.venv', 'venv', 'node_modules', '.git', '.svn', '.hg',
   '__pycache__', '.pytest_cache', '.mypy_cache', '.coverage',


### PR DESCRIPTION
Summary
- Enable custom directories; improve Windows usability.
- Add repeatable --allow <dir> flag to extend allowed directories at startup.
- Centralize allowed-dir checks; align defaults with original intent (HOME, /tmp, /Users, /home; Windows: C:/Users).

Changes
- src/utils.ts: introduce AllowedDirs manager (addAllowedDirectories/getAllowedDirectories); update isPathAllowed/safePath to use a shared Set;.
- src/index.ts: parse --allow; delegate safePath/isPathAllowed to utils; fast_list_allowed_directories returns getAllowedDirectories().
- package.json: add “smoke” script.
- scripts/smoke-stdio.mjs: minimal stdio smoke test to verify --allow behavior.
